### PR TITLE
Get allow-list from config and fix the condition

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -91,6 +91,7 @@ class CharmCharm(ops.CharmBase):
                         "CLIENT_ID": self.model.config["client-id"],
                         "CLIENT_SECRET": self.model.config["client-secret"],
                         "AUTH_SCOPE": self.model.config["auth-scope"],
+                        "ENDPOINT_ALLOW_LIST": self.model.config["endpoint-allow-list"],
                     },
                 }
             },

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -21,6 +21,7 @@ def test_config():
         "client-id": "example-client-id",
         "client-secret": "example-client-secret",
         "auth-scope": "example-scope",
+        "endpoint-allow-list": "GET:/api/v2/example/",
     }
 
 
@@ -62,6 +63,7 @@ def test_config_changed_valid_can_connect():
     assert env["CLIENT_ID"] == "example-client-id"
     assert env["CLIENT_SECRET"] == "example-client-secret"
     assert env["AUTH_SCOPE"] == "example-scope"
+    assert env["ENDPOINT_ALLOW_LIST"] == "GET:/api/v2/example/"
     assert state_out.unit_status == testing.ActiveStatus()
 
     # Check environment keys against charmcraft.yaml
@@ -75,6 +77,7 @@ def test_config_changed_valid_can_connect():
         "CLIENT_ID",
         "CLIENT_SECRET",
         "AUTH_SCOPE",
+        "ENDPOINT_ALLOW_LIST",
     }
     assert env_keys == expected_keys
 

--- a/proxy/app.py
+++ b/proxy/app.py
@@ -94,7 +94,7 @@ allow_list = os.getenv("ENDPOINT_ALLOW_LIST", "").split("|")
 
 from .proxy import create_proxy_routes, filter_endpoints
 
-if allow_list:
+if allow_list != ['']:
     logging.info(f"Filtering API to allow list: {allow_list}")
     openapi_schema = filter_endpoints(openapi_schema, allow_list)
 else:


### PR DESCRIPTION
This PR adds the missing part of fetching `endpoint-allow-list` from the juju config and fixes the condition error below.

```
>  OPENAPI_SCHEMA_URL='https://certification.canonical.com/api/v2/openapi' \
   ORIGIN_BASE_URL='https://certification.canonical.com' \
   HOST='0.0.0.0' \
   PORT=8000 \
   uv run uvicorn proxy.app:app --reload

INFO:     Will watch for changes in these directories: ['/home/nancy-chen/lab-git/openapi-rest-proxy']
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [1548242] using StatReload
INFO:httpx:HTTP Request: GET https://certification.canonical.com/api/v2/openapi "HTTP/1.1 200 OK"
INFO:openapi-rest-proxy:Filtering API to allow list: ['']
Process SpawnProcess-1:
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/.venv/lib/python3.12/site-packages/uvicorn/_subprocess.py", line 80, in subprocess_started
    target(sockets=sockets)
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 66, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 70, in serve
    await self._serve(sockets)
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 77, in _serve
    config.load()
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/.venv/lib/python3.12/site-packages/uvicorn/config.py", line 435, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/.venv/lib/python3.12/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/proxy/app.py", line 99, in <module>
    openapi_schema = filter_endpoints(openapi_schema, allow_list)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nancy-chen/lab-git/openapi-rest-proxy/proxy/proxy.py", line 35, in filter_endpoints
    raise ValueError("No endpoints matched the allow list.")
ValueError: No endpoints matched the allow list.
```